### PR TITLE
Allow use with dahdi-complete package

### DIFF
--- a/build_tools/dkms-helper
+++ b/build_tools/dkms-helper
@@ -65,6 +65,7 @@ add() {
         if [ -d .git ]; then
             ${GIT} checkout-index -a --prefix=/usr/src/dahdi-linux-${VERSION}/
         else
+            mkdir -p /usr/src/dahdi-linux-${VERSION}
             cp -f -r * /usr/src/dahdi-linux-${VERSION}/
         fi
     fi


### PR DESCRIPTION
Due to the way dahdi-complete extracts the dkms-helper script fails to execute.
Added mkdir for expected directory structure, before copy of content.
