### PR TITLE
dahdi: fix pci include for kernels > 5.4

### DIFF
--- a/include/dahdi/kernel.h
+++ b/include/dahdi/kernel.h
@@ -58,7 +58,8 @@
 
 #include <linux/poll.h>
 
-#ifdef CONFIG_PCI
+#if defined(CONFIG_PCI) && \
+	(LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0))
 #include <linux/pci-aspm.h>
 #endif
 


### PR DESCRIPTION
Starting with kernel 5.4 "<linux/pci-aspm.h>" has been removed and its
contents merged into "<linux/pci.h>".

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Hi all,

Small pull request to make compile possible against kernel 5.4.

Kind regards,
Seb