### PR TITLE
dahdi-base.c: remove netdev->trans_start (kernel >= 4.7)

### DIFF
--- a/drivers/dahdi/dahdi-base.c
+++ b/drivers/dahdi/dahdi-base.c
@@ -2131,7 +2131,11 @@ static int dahdi_xmit(struct sk_buff *skb, struct net_device *dev)
 			   some space for us */
 			ss->outwritebuf = oldbuf;
 		}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
+		netif_trans_update(dev);
+#else
 		dev->trans_start = jiffies;
+#endif
 		stats->tx_packets++;
 		stats->tx_bytes += ss->writen[oldbuf];
 		print_debug_writebuf(ss, skb, oldbuf);


### PR DESCRIPTION
In linux kernel commit 4d659fcb20d3d3302b429c889a73a92ff2804b9a
in May 2016, netdev->trans_start was removed and write accesses
are replaced with this helper: netif_trans_update(dev)

This makes dahdi-base.c compile against kernels >= 4.7
when CONFIG_DAHDI_NET is enabled.

Signed-off-by: Harald Welte <laforge@osmocom.org>