### PR TITLE
next: fix kernel 6.1 build

### DIFF
--- a/include/dahdi/kernel.h
+++ b/include/dahdi/kernel.h
@@ -58,6 +58,10 @@
 
 #include <linux/poll.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define netif_napi_add netif_napi_add_weight
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 #include <linux/pci.h>
 #include <linux/dma-mapping.h>


### PR DESCRIPTION
kernel 6.1 cut the weight arg from netif_napi_add: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b48b89f9c189d24eb5e2b4a0ac067da5a24ee86d

only compile tested on aarch64 kernel 6.1rc1

---

I have now discovered the next branch…
It already had the 5.18 pci_ fix