### PR TITLE
 Build support for kernel 6.1

### DIFF
--- a/drivers/dahdi/wctc4xxp/base.c
+++ b/drivers/dahdi/wctc4xxp/base.c
@@ -658,8 +658,12 @@ wctc4xxp_net_register(struct wcdte *wc)
 	netdev->promiscuity = 0;
 	netdev->flags |= IFF_NOARP;
 
+#	if(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
 	netif_napi_add(netdev, &wc->napi, &wctc4xxp_poll, 64);
-
+#	else
+	netif_napi_add(netdev, &wc->napi, &wctc4xxp_poll);
+#	endif
+	
 	res = register_netdev(netdev);
 	if (res) {
 		dev_warn(&wc->pdev->dev,


### PR DESCRIPTION
As of kernel 6.1, `netif_napi_add()` no longer contains the weight in function, and defaults to 64 (the value in code). The new function for setting weight is `netif_napi_add_weight()`