### PR TITLE
dahdi_echocan_mg2: rename ABS define to PARA_ABS

### DIFF
--- a/drivers/dahdi/dahdi_echocan_mg2.c
+++ b/drivers/dahdi/dahdi_echocan_mg2.c
@@ -44,7 +44,7 @@
 static int debug;
 static int aggressive;
 
-#define ABS(a) abs(a!=-32768?a:-32767)
+#define PARA_ABS(a) abs(a!=-32768?a:-32767)
 
 #define RESTORE_COEFFS {\
 				int x;\
@@ -464,9 +464,9 @@ static inline short sample_update(struct ec_pvt *pvt, short iref, short isig)
 			RESTORE_COEFFS;
 		}
 
-		sign_error = ABS(rs) - ABS(isig);
+		sign_error = PARA_ABS(rs) - PARA_ABS(isig);
 
-		if (ABS(sign_error) > MAX_SIGN_ERROR)
+		if (PARA_ABS(sign_error) > MAX_SIGN_ERROR)
 		{
 			rs = 0;
 			RESTORE_COEFFS;


### PR DESCRIPTION
Rename ABS define to PARA_ABS to fix compilation error with mips 24kc arch.

This target define in his ASM header a similar define ABS that cause conflicts and redefinition error for this driver.

Rename ABS to PARA_ABS to better suite the usage as it's abs usage with value decremented by one if it's the max negative int.