### PR TITLE
fix missing spantype file from dahdi-tools

### DIFF
--- a/drivers/dahdi/dahdi-sysfs.c
+++ b/drivers/dahdi/dahdi-sysfs.c
@@ -704,8 +704,16 @@ static DEVICE_ATTR_RO(location);
 static DEVICE_ATTR_WO(auto_assign);
 static DEVICE_ATTR_WO(assign_span);
 static DEVICE_ATTR_WO(unassign_span);
-static DEVICE_ATTR_RW(dahdi_spantype);
-static DEVICE_ATTR_RO(dahdi_registration_time);
+static struct device_attribute dev_attr_dahdi_spantype = {
+	.attr   = { .name = "spantype", .mode = 0644 },
+	.show   = dahdi_spantype_show,
+	.store  = dahdi_spantype_store,
+};
+static struct device_attribute dev_attr_dahdi_registration_time = {
+	.attr   = { .name = "registration_time", .mode = 0444 },
+	.show   = dahdi_registration_time_show,
+	.store  = NULL,
+};
 static struct attribute *dahdi_device_attrs[] = {
 	&dev_attr_manufacturer.attr,
 	&dev_attr_type.attr,


### PR DESCRIPTION
With Linux kernel >= 4.13.0 the dahdi-tools don't work, complaining that they don't find "spantype". This is due to a name-change of the sysfs entry. This change seems to be accidental due to a name clash in the c source file.

This patch changes the name to back to "spantype" and hence fixes https://github.com/asterisk/dahdi-tools/issues/9.