### PR TITLE
kernel.h: Fix netif_napi_add API arguments for RHEL.

### DIFF
--- a/include/dahdi/kernel.h
+++ b/include/dahdi/kernel.h
@@ -60,6 +60,10 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #define netif_napi_add netif_napi_add_weight
+#elif defined(RHEL_RELEASE_VERSION) && defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2)) || (RHEL_MAJOR == 8 && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 8))
+#define netif_napi_add netif_napi_add_weight
+#endif /* RHEL_RELEASE_CODE */
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
@@ -1555,7 +1559,6 @@ static inline void *PDE_DATA(const struct inode *inode)
 #ifdef RHEL_RELEASE_VERSION
 #if defined(RHEL_RELEASE_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && \
               RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,1)
-#define netif_napi_add netif_napi_add_weight
 #define PDE_DATA(i)     pde_data(i)
 #endif
 #endif


### PR DESCRIPTION
Commit 08fda500eda8893fddb269e07e3b1eaafd0a684b fixed this issue for some versions of RHEL, but not all of them, and in particular did not fix the issue on RHEL 8 past 8.8. This improves the targeting for RHEL for a more comprehensive fix.

Resolves: #38