### PR TITLE
wct4xxp: Eliminate old-style declaration.

### DIFF
--- a/drivers/dahdi/wct4xxp/base.c
+++ b/drivers/dahdi/wct4xxp/base.c
@@ -1172,7 +1172,7 @@ static int t4_ioctl(struct dahdi_chan *chan, unsigned int cmd, unsigned long dat
 	return 0;
 }
 
-static void inline t4_hdlc_xmit_fifo(struct t4 *wc, unsigned int span, struct t4_span *ts)
+static inline void t4_hdlc_xmit_fifo(struct t4 *wc, unsigned int span, struct t4_span *ts)
 {
 	int res, i;
 	unsigned int size = 32;


### PR DESCRIPTION
Fix a single instance of functions being declared inline after their return type, which causes a compiler error on newer systems.

Resolves: #59