### PR TITLE
xpp: Add braces around empty if statements.

### DIFF
--- a/drivers/dahdi/xpp/card_fxs.c
+++ b/drivers/dahdi/xpp/card_fxs.c
@@ -1169,10 +1169,12 @@ static int set_vmwi(xpd_t *xpd, int pos, unsigned long arg)
 			    "%s: VMWI(hvdc) is not implemented yet. Ignored.\n",
 			    __func__);
 	}
-	if (VMWI_TYPE(priv, pos, HVAC))
+	if (VMWI_TYPE(priv, pos, HVAC)) {
 		;		/* VMWI_NEON */
-	if (priv->vmwisetting[pos].vmwi_type == 0)
+	}
+	if (priv->vmwisetting[pos].vmwi_type == 0) {
 		;		/* Disable VMWI */
+	}
 	priv->vmwisetting[pos] = vmwisetting;
 	set_vm_led_mode(xpd->xbus, xpd, pos, PHONEDEV(xpd).msg_waiting[pos]);
 	return 0;


### PR DESCRIPTION
Avoid compilation failure on modern kernels by adding braces around empty if body.

Resolves: #65