### PR TITLE
wctdm24xxp, voicebus: Fix DEFINE_SEMAPHORE for RHEL.

### DIFF
--- a/drivers/dahdi/voicebus/voicebus.c
+++ b/drivers/dahdi/voicebus/voicebus.c
@@ -1136,7 +1136,15 @@ static void vb_stop_txrx_processors(struct voicebus *vb)
 void voicebus_stop(struct voicebus *vb)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+#if defined(RHEL_RELEASE_VERSION) && defined(RHEL_RELEASE_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
+	static DEFINE_SEMAPHORE(stop, 1);
+#else
 	static DEFINE_SEMAPHORE(stop);
+#endif /* RHEL_RELEASE_CODE */
+#else
+	static DEFINE_SEMAPHORE(stop);
+#endif /* RHEL_RELEASE_VERSION */
 #else
 	static DEFINE_SEMAPHORE(stop, 1);
 #endif

--- a/drivers/dahdi/wctdm24xxp/base.c
+++ b/drivers/dahdi/wctdm24xxp/base.c
@@ -230,7 +230,15 @@ mod_hooksig(struct wctdm *wc, struct wctdm_module *mod, enum dahdi_rxsig rxsig)
 
 struct wctdm *ifaces[WC_MAX_IFACES];
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+#if defined(RHEL_RELEASE_VERSION) && defined(RHEL_RELEASE_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
+DEFINE_SEMAPHORE(ifacelock, 1);
+#else
 DEFINE_SEMAPHORE(ifacelock);
+#endif /* RHEL_RELEASE_CODE */
+#else
+DEFINE_SEMAPHORE(ifacelock);
+#endif /* RHEL_RELEASE_VERSION */
 #else
 DEFINE_SEMAPHORE(ifacelock, 1);
 #endif


### PR DESCRIPTION
RHEL 9.3 and newer also include the newer DEFINE_SEMAPHORE definition in kernels 6.4.0 and newer.

Resolves: #67