### PR TITLE
kernel.h: Add wrappers for del_timer and del_timer_sync.

### DIFF
--- a/include/dahdi/kernel.h
+++ b/include/dahdi/kernel.h
@@ -66,6 +66,11 @@
 #endif /* RHEL_RELEASE_CODE */
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+#define del_timer timer_delete
+#define del_timer_sync timer_delete_sync
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 #include <linux/pci.h>
 #include <linux/dma-mapping.h>


### PR DESCRIPTION
del_timer[_sync] was renamed to timer_delete[_sync] in kernel
commit bb663f0f3c396c6d05f6c5eeeea96ced20ff112e, and the
compatibility wrappers were removed completely in kernel commit
8fa7292fee5c5240402371ea89ab285ec856c916. Add the wrappers
back on newer kernels to allow compilation.

Resolves: #91