### PR TITLE
kernel.h: Add wrapper for renamed from_timer function.

### DIFF
--- a/include/dahdi/kernel.h
+++ b/include/dahdi/kernel.h
@@ -58,6 +58,10 @@
 
 #include <linux/poll.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+#define from_timer timer_container_of
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #define netif_napi_add netif_napi_add_weight
 #elif defined(RHEL_RELEASE_VERSION) && defined(RHEL_RELEASE_CODE)


### PR DESCRIPTION
from_timer was renamed to timer_container_of in kernel commit 41cb08555c4164996d67c78b3bf1c658075b75f1 as part of updates to the timer APIs. Add a compatibility wrapper for kernels >= 6.16.0.

Resolves: #95