### PR TITLE
dahdi_dummy: Use module_init/module_exit instead of init_module/cleanup_module.

### DIFF
--- a/drivers/dahdi/dahdi_dummy.c
+++ b/drivers/dahdi/dahdi_dummy.c
@@ -209,7 +209,7 @@ static int dahdi_dummy_initialize(struct dahdi_dummy *ztd)
 	return res;
 }
 
-int init_module(void)
+static int __init dummy_init(void)
 {
 	int res;
 	ztd = kzalloc(sizeof(*ztd), GFP_KERNEL);
@@ -250,8 +250,7 @@ int init_module(void)
 	return 0;
 }
 
-
-void cleanup_module(void)
+static void __exit dummy_exit(void)
 {
 #if defined(USE_HIGHRESTIMER)
 	/* Stop high resolution timer */
@@ -272,3 +271,6 @@ module_param(debug, int, 0600);
 MODULE_DESCRIPTION("Timing-Only Driver");
 MODULE_AUTHOR("Robert Pleh <robert.pleh@hermes.si>");
 MODULE_LICENSE("GPL v2");
+
+module_init(dummy_init);
+module_exit(dummy_exit);


### PR DESCRIPTION
Since kernel commit 4fab2d7628dd38f3fa8a5e615199350ecaeb17a8, building dahdi_dummy fails with an objtool failure since init_module/cleanup_module are deprecated. Update dahdi_dummy to use module_init and module_exit, just like all other modules.

Resolves: #94