### PR TITLE
dahdi_base.c: Avoid unnecessary strlen call when with strncat.

### DIFF
--- a/drivers/dahdi/dahdi-base.c
+++ b/drivers/dahdi/dahdi-base.c
@@ -5402,14 +5402,12 @@ static int dahdi_ioctl_get_version(unsigned long data)
 			 */
 			 continue;
 		}
-		strncat(vi.echo_canceller + strlen(vi.echo_canceller),
-			ec_name, space);
+		strncat(vi.echo_canceller, ec_name, space);
 		space -= strlen(ec_name);
 		if (space < 1)
 			break;
 		if (cur->list.next && (cur->list.next != &ecfactory_list)) {
-			strncat(vi.echo_canceller + strlen(vi.echo_canceller),
-				", ", space);
+			strncat(vi.echo_canceller, ", ", space);
 			space -= 2;
 			if (space < 1)
 				break;


### PR DESCRIPTION
It is not necessary to call strlen on the destination buffer when calling strncat.

Resolves: #89