### PR TITLE
Fix astribank_match const signature for RHEL 9.8+

### DIFF
--- a/drivers/dahdi/dahdi-sysfs-chan.c
+++ b/drivers/dahdi/dahdi-sysfs-chan.c
@@ -220,7 +220,7 @@ static void chan_release(struct device *dev)
 	chan_dbg(DEVICES, chan, "SYSFS\n");
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
 static int chan_match(struct device *dev, const struct device_driver *driver)
 #else
 static int chan_match(struct device *dev, struct device_driver *driver)

--- a/drivers/dahdi/dahdi-sysfs.c
+++ b/drivers/dahdi/dahdi-sysfs.c
@@ -42,7 +42,7 @@ module_param(tools_rootdir, charp, 0444);
 MODULE_PARM_DESC(tools_rootdir,
 		"root directory of all tools paths (default /)");
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
 static int span_match(struct device *dev, const struct device_driver *driver)
 #else
 static int span_match(struct device *dev, struct device_driver *driver)

--- a/drivers/dahdi/xpp/xbus-sysfs.c
+++ b/drivers/dahdi/xpp/xbus-sysfs.c
@@ -397,7 +397,7 @@ static struct attribute *xbus_dev_attrs[] = {
 ATTRIBUTE_GROUPS(xbus_dev);
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
 static int astribank_match(struct device *dev, const struct device_driver *driver)
 #else
 static int astribank_match(struct device *dev, struct device_driver *driver)
@@ -778,7 +778,7 @@ static DEVICE_ATTR_READER(refcount_xpd_show, dev, buf)
 	return len;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
 static int xpd_match(struct device *dev, const struct device_driver *driver)
 #else
 static int xpd_match(struct device *dev, struct device_driver *driver)


### PR DESCRIPTION
RHEL 9.8+ (kernel 5.14) backported the const struct device_driver * change to match callbacks, causing a -Werror=incompatible-pointer-types build failure. Extends the existing kernel 6.11 guards to also cover RHEL 9.8+.
Resolves #104