### PR TITLE
kernel.h: Add wrapper for renamed from_timer function for rhel 8.9

### DIFF
--- a/drivers/dahdi/dahdi-sysfs-chan.c
+++ b/drivers/dahdi/dahdi-sysfs-chan.c
@@ -220,7 +220,7 @@ static void chan_release(struct device *dev)
 	chan_dbg(DEVICES, chan, "SYSFS\n");
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) || RHEL_VERSION_GE(9, 8)
 static int chan_match(struct device *dev, const struct device_driver *driver)
 #else
 static int chan_match(struct device *dev, struct device_driver *driver)

--- a/drivers/dahdi/dahdi-sysfs.c
+++ b/drivers/dahdi/dahdi-sysfs.c
@@ -42,7 +42,7 @@ module_param(tools_rootdir, charp, 0444);
 MODULE_PARM_DESC(tools_rootdir,
 		"root directory of all tools paths (default /)");
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) || RHEL_VERSION_GE(9, 8)
 static int span_match(struct device *dev, const struct device_driver *driver)
 #else
 static int span_match(struct device *dev, struct device_driver *driver)

--- a/drivers/dahdi/xpp/xbus-sysfs.c
+++ b/drivers/dahdi/xpp/xbus-sysfs.c
@@ -397,7 +397,7 @@ static struct attribute *xbus_dev_attrs[] = {
 ATTRIBUTE_GROUPS(xbus_dev);
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) || RHEL_VERSION_GE(9, 8)
 static int astribank_match(struct device *dev, const struct device_driver *driver)
 #else
 static int astribank_match(struct device *dev, struct device_driver *driver)
@@ -778,7 +778,7 @@ static DEVICE_ATTR_READER(refcount_xpd_show, dev, buf)
 	return len;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) ||(defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8)))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0) || RHEL_VERSION_GE(9, 8)
 static int xpd_match(struct device *dev, const struct device_driver *driver)
 #else
 static int xpd_match(struct device *dev, struct device_driver *driver)

--- a/include/dahdi/kernel.h
+++ b/include/dahdi/kernel.h
@@ -58,7 +58,14 @@
 
 #include <linux/poll.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+#ifndef RHEL_VERSION_GE
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#define RHEL_VERSION_GE(maj, min) (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(maj, min))
+#else
+#define RHEL_VERSION_GE(maj, min) (0)
+#endif
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0) || RHEL_VERSION_GE(9, 8)
 #define from_timer timer_container_of
 #endif
 


### PR DESCRIPTION
kernel.h: Add wrapper for renamed from_timer function for rhel 8.9
see original issue #95

Introduce `RHEL_VERSION_GE()` helper to simplify and standardize RHEL version checks.
Future checks can use `RHEL_VERSION_GE(x, y)` instead of repeating the full macro guard.